### PR TITLE
Update paper-datatable.html

### DIFF
--- a/paper-datatable.html
+++ b/paper-datatable.html
@@ -1021,7 +1021,7 @@ Mixins
 						// see: console.log(this._columns.length);
 
 						var ths = Polymer.dom(this.root).querySelectorAll('th');
-						ths.forEach((th) => {
+						ths.forEach(function(th) {
 							if(th.dataColumn){
 								console.dir(th);
 								var column = th.dataColumn;


### PR DESCRIPTION
The changed code was ES6, and very similar to the ES5 equivalent. Since ES6 support is still limited it seems logical to, for now, use the ES5 version.
Also it broke the polybuild tool.
