### PR TITLE
Add missing paper-drawer-panel to devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,6 +39,7 @@
     "paper-progress": "PolymerElements/paper-progress#~1.0.7",
     "paper-menu": "PolymerElements/paper-menu#~1.1.1",
     "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#~1.1.0",
-    "paper-input": "PolymerElements/paper-input#~1.0.18"
+    "paper-input": "PolymerElements/paper-input#~1.0.18",
+    "paper-drawer-panel": "PolymerElements/paper-drawer-panel#~1.0.6"
   }
 }


### PR DESCRIPTION
Demos did not work properly without paper-drawer-panel. I think it should be added to devDependencies.
