### PR TITLE
Add removeSelectedRows API method

### DIFF
--- a/paper-datatable.html
+++ b/paper-datatable.html
@@ -525,9 +525,13 @@ A [material design implementation of a data table](https://www.google.com/design
 					});
 				},
 
-				_setRowKeys: function(){
+				_setRowKeys: function(splices){
 					var rowKeys = [];
 					this._dataKeyCollection = Polymer.Collection.get(this.data);
+					if (splices) {
+						// ensure no lingering indices exist that point to removed elements
+						Polymer.Collection.applySplices(this.data, splices);
+					}
 					this.data.forEach(function(row){
 						var key = this._dataKeyCollection.getKey(row);
 						if('filter' in this){
@@ -839,7 +843,21 @@ A [material design implementation of a data table](https://www.google.com/design
 						}
 					}
 				},
-
+				/**
+				 * Removes all selected elements from the dataset and the view
+				 */
+				removeSelectedRows: function () {
+					var i = 0, key=null;
+					for (i; i < this.selectedKeys.length; ++i) {
+						key = this.selectedKeys[i];
+						this.splice('selectedKeys', i--, 1);
+						this._removeRowAtKey(key);
+					}
+				},
+				_removeRowAtKey: function(key) {
+					var obj = this._getByKey(key);
+					this.splice('data', this.data.indexOf(obj), 1);
+				},
 				/**
 				 * Sort the specified column, where `column` is a reference to the actual `<paper-datatable-column>`
 				 * element.


### PR DESCRIPTION
This change adds an API method that removes all selected rows from the dataset and the DOM.

This change is observed by the already present function _setRowKeys which observes changes to data.splices. I added a call to `Polymer.Collection.applySplices` here to prevent subsequent select events being thrown with keys that refer to incorrect or non-existing items.

Disclaimer:
"I hereby grant you, David-Mulder, a generic right to relicense this contribution under any license and the discretion to license the project as a whole to any parties under those licenses"
