### PR TITLE
Adding mixins for paper checkbox size

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -46,6 +46,8 @@ Mixins
  ------|-------------
  `--paper-datatable-column-header` | column header style applied to text headers
  `--paper-datatable-cell` | applied to all data cells
+ `--paper-datatable-header-checkbox-size` | size of all selectable header checkboxe
+ `--paper-datatable-checkbox-size` | size of all selectable checkboxes
  `--paper-datatable-cell-last` | applied to the last cell of each row (used to increase the `padding-right` if you overwrite it in `--paper-datatable-cell`)
  `--paper-datatable-column-header-sorted` | applied to the sort icon
  `--paper-datatable-column-header-sort-icon-hover` | applied to the sort icon when hovered

--- a/paper-datatable.html
+++ b/paper-datatable.html
@@ -205,16 +205,18 @@
 			paper-checkbox{
 				--paper-checkbox-unchecked-color: var(--paper-datatable-checkbox-border-color, --primary-text-color);
 				--paper-checkbox-checked-color: var(--paper-datatable-checkbox-color, --accent-color);
+				--paper-checkbox-size: var(--paper-datatable-checkbox-size);
 				@apply(--paper-datatable-checkbox);
 			}
 			th paper-checkbox{
 				--paper-checkbox-unchecked-color: var(--paper-datatable-header-checkbox-border-color, --primary-text-color);
 				--paper-checkbox-checked-color: var(--paper-datatable-header-checkbox-color, --accent-color);
+				--paper-checkbox-size: var(--paper-datatable-header-checkbox-size);
 				@apply(--paper-datatable-header-checkbox);
 			}
 			.partialSelectionContainer{
-				width:18px;
-				height:18px;
+				width:var(--paper-datatable-header-checkbox-size,18px);
+				height:var(--paper-datatable-header-checkbox-size,18px);
 				position:relative;
 				display:flex;
 				align-items:center;


### PR DESCRIPTION
Although paper datatable has the mixins _--paper-datatable-column-header_ and _--paper-datatable-cell_ through which we can customize header and cell styles eg: padding/height etc, but in case of selectable checkbox this fails as the height of the row increases to adjust the checkbox size. 

However checkbox size in itself is a mixin from paper-checkbox(_--paper-checkbox-size_) but here _--paper-datatable-checkbox_ and _--paper-datatable-header-checkbox_ don't help because of the nested mixin issue as addressed in [polymer#3746](https://github.com/Polymer/polymer/issues/3746).

Hence adding two new mixin variable as _**--paper-datatable-header-checkbox-size**_ and _**--paper-datatable-checkbox-size**_ so that checkbox size can be passed. If variable not passed it will be default by paper checkbox as 18px. Also adjusting the size of the partialSelectionContainer class to adjust as the checkbox provided size.

A very straight-forward and simple pull request but helps in styling as height 56px is too much of real-estate for a field in custom styling. Hope it helps.  